### PR TITLE
Update tests to triava cache v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ bash jmh-run.sh
 bash processJmhResults.sh --dir /var/run/shm/jmh-result process
 ```
 
-This requires Linux and gnuplot. Single benchmarks can alternatively be run
+This requires Linux with gnuplot, pandoc and asciidoctor. Single benchmarks can alternatively be run
 via: `java -jar jmh-suite/target/benchmarks.jar [ jmh-parameters ]`
 
 ## The maven modules

--- a/jmh-run.sh
+++ b/jmh-run.sh
@@ -164,7 +164,7 @@ test -d $TARGET || mkdir -p $TARGET;
 if test -n "$backends"; then
   COMPLETE="$backends";
 elif test -z "$no3pty"; then
-  COMPLETE="$COMPLETE thirdparty.CaffeineCacheFactory thirdparty.GuavaCacheFactory thirdparty.EhCache2Factory";
+  COMPLETE="$COMPLETE thirdparty.CaffeineCacheFactory thirdparty.GuavaCacheFactory thirdparty.EhCache2Factory thirdparty.TCache1Factory";
   # "thirdparty.EhCache3Factory";
 fi
 

--- a/processJmhResults.sh
+++ b/processJmhResults.sh
@@ -33,7 +33,8 @@ sed "$script";
 CACHE_FACTORY_LIST="org.cache2k.benchmark.Cache2kFactory \
 org.cache2k.benchmark.thirdparty.CaffeineCacheFactory \
 org.cache2k.benchmark.thirdparty.GuavaCacheFactory \
-org.cache2k.benchmark.thirdparty.EhCache2Factory";
+org.cache2k.benchmark.thirdparty.EhCache2Factory \
+org.cache2k.benchmark.thirdparty.TCache1Factory";
 
 # "org.cache2k.benchmark.thirdparty.EhCache3Factory";
 

--- a/thirdparty/pom.xml
+++ b/thirdparty/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.trivago</groupId>
       <artifactId>triava</artifactId>
-      <version>0.9.5</version>
+      <version>1.0.4</version>
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache.internal</groupId>

--- a/thirdparty/src/main/java/org/cache2k/benchmark/thirdparty/TCache1Factory.java
+++ b/thirdparty/src/main/java/org/cache2k/benchmark/thirdparty/TCache1Factory.java
@@ -27,10 +27,11 @@ package org.cache2k.benchmark.thirdparty;
 
 import com.trivago.triava.tcache.TCacheFactory;
 import com.trivago.triava.tcache.core.Builder;
-import com.trivago.triava.tcache.eviction.Cache;
+import com.trivago.triava.tcache.Cache;
 import org.cache2k.benchmark.BenchmarkCache;
 import org.cache2k.benchmark.BenchmarkCacheFactory;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -45,7 +46,7 @@ public class TCache1Factory extends BenchmarkCacheFactory {
   public BenchmarkCache<Integer, Integer> create(int _maxElements) {
     TCacheFactory factory = TCacheFactory.standardFactory();
     Builder<Integer, Integer> b = factory.builder();
-    b.setExpectedMapSize(_maxElements);
+    b.setMaxElements(_maxElements);
 
     /**
      * Set a cache name. For some reason, auto-assigning a name does not work properly in this JMH based test.
@@ -57,22 +58,20 @@ public class TCache1Factory extends BenchmarkCacheFactory {
     b.setId(id);
 
     if (withExpiry) {
-      b.setMaxCacheTime(5 * 60);
-      b.setMaxIdleTime(5 * 60);
+      b.setMaxCacheTime(5, TimeUnit.MINUTES);
+      b.setMaxIdleTime(5, TimeUnit.MINUTES);
     }
 
-    return new MyBenchmarkCacheAdapter(b, _maxElements, factory);
+    return new MyBenchmarkCacheAdapter(b, _maxElements);
   }
 
   static class MyBenchmarkCacheAdapter extends BenchmarkCache<Integer, Integer> {
     final int size;
     final Cache<Integer, Integer> cache;
-    final public TCacheFactory factory;
 
-    public MyBenchmarkCacheAdapter(Builder<Integer, Integer> builder, int maxElements, TCacheFactory factory) {
+    public MyBenchmarkCacheAdapter(Builder<Integer, Integer> builder, int maxElements) {
       super();
       this.size = maxElements;
-      this.factory = factory;
       this.cache = builder.build();
     }
 
@@ -93,7 +92,7 @@ public class TCache1Factory extends BenchmarkCacheFactory {
 
     @Override
     public void close() {
-      factory.destroyCache(cache.id());
+        cache.close();
     }
 
     @Override


### PR DESCRIPTION
Update to triava v1.0.4
- Follow last API changes between 0.9.5 and 1.0
- Fix omissions for triava in the JMH tests

README updates

